### PR TITLE
Compiler fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.o
 libgl-matrix.a
 .DS_Store
+glmatrix.h

--- a/Makefile
+++ b/Makefile
@@ -3,15 +3,21 @@ LFLAGS=
 LIB_PATH=/usr/local/lib
 INCLUDE_PATH=/usr/local/include
 
-all: vec3.o mat3.o mat4.o quat.o str.o
-	ar -rcs libgl-matrix.a vec3.o mat3.o mat4.o quat.o str.o
+all: vec2.o vec3.o vec4.o mat3.o mat4.o quat.o str.o
+	ar -rcs libgl-matrix.a vec2.o vec3.o vec4.o mat3.o mat4.o quat.o str.o
 
 clean:
-	rm vec3.o mat3.o mat4.o quat.o str.o 
+	rm vec3.o mat3.o mat4.o quat.o str.o
 	rm libgl-matrix.a
-	
+
+vec2.o: vec2.c
+	$(CC) -c vec2.c $(CFLAGS) -o vec2.o
+
 vec3.o: vec3.c
 	$(CC) -c vec3.c $(CFLAGS) -o vec3.o
+
+vec4.o: vec4.c
+	$(CC) -c vec4.c $(CFLAGS) -o vec4.o
 
 mat3.o: mat3.c
 	$(CC) -c mat3.c $(CFLAGS) -o mat3.o

--- a/Makefile
+++ b/Makefile
@@ -3,34 +3,43 @@ LFLAGS=
 LIB_PATH=/usr/local/lib
 INCLUDE_PATH=/usr/local/include
 
-all: vec2.o vec3.o vec4.o mat3.o mat4.o quat.o str.o
-	ar -rcs libgl-matrix.a vec2.o vec3.o vec4.o mat3.o mat4.o quat.o str.o
+SOURCES=vec2.c vec3.c vec4.c mat3.c mat4.c quat.c str.c
+OBJECTS=$(SOURCES:.c=.o)
+
+all: libgl-matrix.a glmatrix.h
+
+libgl-matrix.a: $(OBJECTS)
+	ar -rcs libgl-matrix.a $(OBJECTS)
 
 clean:
-	rm vec3.o mat3.o mat4.o quat.o str.o
-	rm libgl-matrix.a
+	-rm $(OBJECTS)
+	-rm libgl-matrix.a
+	-rm glmatrix.h
 
-vec2.o: vec2.c
-	$(CC) -c vec2.c $(CFLAGS) -o vec2.o
+.c.o:
+	$(CC) -c $< $(CFLAGS) -o $@
 
-vec3.o: vec3.c
-	$(CC) -c vec3.c $(CFLAGS) -o vec3.o
-
-vec4.o: vec4.c
-	$(CC) -c vec4.c $(CFLAGS) -o vec4.o
-
-mat3.o: mat3.c
-	$(CC) -c mat3.c $(CFLAGS) -o mat3.o
-
-mat4.o: mat4.c
-	$(CC) -c mat4.c $(CFLAGS) -o mat4.o
-
-quat.o: quat.c
-	$(CC) -c quat.c $(CFLAGS) -o quat.o
-
-str.o: str.c
-	$(CC) -c str.c $(CFLAGS) -o str.o
+vec2.o: vec2.c gl-matrix.h
+vec3.o: vec3.c gl-matrix.h
+vec4.o: vec4.c gl-matrix.h
+mat3.o: mat3.c gl-matrix.h
+mat4.o: mat4.c gl-matrix.h
+quat.o: quat.c gl-matrix.h
+str.o: str.c gl-matrix.h
 
 install:
 	cp libgl-matrix.a $(LIB_PATH)/libgl-matrix.a
 	cp gl-matrix.h $(INCLUDE_PATH)/gl-matrix.h
+
+# Single header file library
+glmatrix.h: gl-matrix.h $(SOURCES)
+	echo '/* Single header library version.' > $@
+	echo ' * You need to `#define GL_MATRIX_IMPLEMENTATION` in one of your source files' >> $@
+	echo ' */' >> $@
+	cat gl-matrix.h >> $@
+	echo '#ifdef GL_MATRIX_IMPLEMENTATION' >> $@
+	echo '#include <stdio.h>' >> $@
+	echo '#include <stdlib.h>' >> $@
+	echo '#include <math.h>' >> $@
+	sed '/#include.*$$/d' $(SOURCES) >> $@
+	echo '#endif /* GL_MATRIX_IMPLEMENTATION */' >> $@

--- a/Makefile
+++ b/Makefile
@@ -3,26 +3,26 @@ LFLAGS=
 LIB_PATH=/usr/local/lib
 INCLUDE_PATH=/usr/local/include
 
-all: vec3 mat3 mat4 quat str
+all: vec3.o mat3.o mat4.o quat.o str.o
 	ar -rcs libgl-matrix.a vec3.o mat3.o mat4.o quat.o str.o
 
 clean:
 	rm vec3.o mat3.o mat4.o quat.o str.o 
 	rm libgl-matrix.a
 	
-vec3: vec3.c
+vec3.o: vec3.c
 	$(CC) -c vec3.c $(CFLAGS) -o vec3.o
 
-mat3: mat3.c
+mat3.o: mat3.c
 	$(CC) -c mat3.c $(CFLAGS) -o mat3.o
 
-mat4: mat4.c
+mat4.o: mat4.c
 	$(CC) -c mat4.c $(CFLAGS) -o mat4.o
 
-quat: quat.c
+quat.o: quat.c
 	$(CC) -c quat.c $(CFLAGS) -o quat.o
 
-str: str.c
+str.o: str.c
 	$(CC) -c str.c $(CFLAGS) -o str.o
 
 install:

--- a/Makefile
+++ b/Makefile
@@ -33,8 +33,14 @@ install:
 
 # Single header file library
 glmatrix.h: gl-matrix.h $(SOURCES)
-	echo '/* Single header library version.' > $@
+	echo '/* Single header library vector and matrix library.' > $@
 	echo ' * You need to `#define GL_MATRIX_IMPLEMENTATION` in one of your source files' >> $@
+	echo ' * Single header version which can be obtained at <https://github.com/wernsey/gl-matrix.c>' >> $@
+	echo ' * Modified from the original C port by Marco Buono <https://github.com/coreh/gl-matrix.c>' >> $@
+	echo " * Which was ported to C from Brandon Jones' original JavaScript version <https://github.com/toji/gl-matrix>" >> $@
+	echo '' >> $@
+	cat LICENSE >> $@
+	echo '' >> $@
 	echo ' */' >> $@
 	cat gl-matrix.h >> $@
 	echo '#ifdef GL_MATRIX_IMPLEMENTATION' >> $@

--- a/Makefile
+++ b/Makefile
@@ -33,19 +33,20 @@ install:
 
 # Single header file library
 glmatrix.h: gl-matrix.h $(SOURCES)
-	echo '/* Single header library vector and matrix library.' > $@
-	echo ' * You need to `#define GL_MATRIX_IMPLEMENTATION` in one of your source files' >> $@
-	echo ' * Single header version which can be obtained at <https://github.com/wernsey/gl-matrix.c>' >> $@
-	echo ' * Modified from the original C port by Marco Buono <https://github.com/coreh/gl-matrix.c>' >> $@
-	echo " * Which was ported to C from Brandon Jones' original JavaScript version <https://github.com/toji/gl-matrix>" >> $@
-	echo '' >> $@
-	cat LICENSE >> $@
-	echo '' >> $@
-	echo ' */' >> $@
-	cat gl-matrix.h >> $@
-	echo '#ifdef GL_MATRIX_IMPLEMENTATION' >> $@
-	echo '#include <stdio.h>' >> $@
-	echo '#include <stdlib.h>' >> $@
-	echo '#include <math.h>' >> $@
-	sed '/#include.*$$/d' $(SOURCES) >> $@
-	echo '#endif /* GL_MATRIX_IMPLEMENTATION */' >> $@
+	@echo Generating $@
+	@echo '/* Single header library vector and matrix library.' > $@
+	@echo ' * You need to `#define GL_MATRIX_IMPLEMENTATION` in one of your source files' >> $@
+	@echo ' * Single header version which can be obtained at <https://github.com/wernsey/gl-matrix.c>' >> $@
+	@echo ' * Modified from the original C port by Marco Buono <https://github.com/coreh/gl-matrix.c>' >> $@
+	@echo " * Which was ported to C from Brandon Jones' original JavaScript version <https://github.com/toji/gl-matrix>" >> $@
+	@echo '' >> $@
+	@cat LICENSE >> $@
+	@echo '' >> $@
+	@echo ' */' >> $@
+	@cat gl-matrix.h >> $@
+	@echo '#ifdef GL_MATRIX_IMPLEMENTATION' >> $@
+	@echo '#include <stdio.h>' >> $@
+	@echo '#include <stdlib.h>' >> $@
+	@echo '#include <math.h>' >> $@
+	@sed '/#include.*$$/d' $(SOURCES) >> $@
+	@echo '#endif /* GL_MATRIX_IMPLEMENTATION */' >> $@

--- a/README
+++ b/README
@@ -1,3 +1,5 @@
+This was forked from https://github.com/coreh/gl-matrix.c
+
 This is a fairly straightforward port of gl-matrix.js (https://github.com/toji/gl-matrix)
 from JavaScript to C.
 

--- a/README
+++ b/README
@@ -1,4 +1,7 @@
-This was forked from https://github.com/coreh/gl-matrix.c
+This was modified from Marco Buono's https://github.com/coreh/gl-matrix.c
+to add support for `vec2_t`, `vec4_t` and single header file library.
+
+The modifications are at https://github.com/wernsey/gl-matrix.c
 
 This is a fairly straightforward port of gl-matrix.js (https://github.com/toji/gl-matrix)
 from JavaScript to C.

--- a/gl-matrix.h
+++ b/gl-matrix.h
@@ -22,11 +22,188 @@ extern "C" {
                               (GL_MATRIX_MINOR_VERSION << 8) | \
                               (GL_MATRIX_MICRO_VERSION))
 
+typedef double *vec2_t;
 typedef double *vec3_t;
 typedef double *vec4_t;
 typedef double *mat3_t;
 typedef double *mat4_t;
 typedef double *quat_t;
+
+/*
+ * vec2_t - 2 Dimensional Vector
+ */
+
+/*
+ * vec2_create
+ * Creates a new instance of a vec2_t
+ *
+ * Params:
+ * vec - Optional, vec2_t containing values to initialize with. If NULL, the 
+ * vector will be initialized with zeroes.
+ *
+ * Returns:
+ * New vec2
+ */
+vec2_t vec2_create(vec2_t vec);
+
+/*
+ * vec2_set
+ * Copies the values of one vec2_t to another
+ *
+ * Params:
+ * vec - vec2_t containing values to copy
+ * dest - vec2_t receiving copied values
+ *
+ * Returns:
+ * dest
+ */
+vec2_t vec2_set(vec2_t vec, vec2_t dest);
+
+/*
+ * vec2_add
+ * Performs a vector addition
+ *
+ * Params:
+ * vec - vec2, first operand
+ * vec2 - vec2, second operand
+ * dest - Optional, vec2_t receiving operation result. If NULL, result is written to vec
+ *
+ * Returns:
+ * dest if not NULL, vec otherwise
+ */
+vec2_t vec2_add(vec2_t vec, vec2_t vec2, vec2_t dest);
+
+/*
+ * vec2_subtract
+ * Performs a vector subtraction
+ *
+ * Params:
+ * vec - vec2, first operand
+ * vec2 - vec2, second operand
+ * dest - Optional, vec2_t receiving operation result. If NULL, result is written to vec
+ *
+ * Returns:
+ * dest if not NULL, vec otherwise
+ */
+vec2_t vec2_subtract(vec2_t vec, vec2_t vec2, vec2_t dest);
+
+/*
+ * vec2_negate
+ * Negates the components of a vec2
+ *
+ * Params:
+ * vec - vec2_t to negate
+ * dest - Optional, vec2_t receiving operation result. If NULL, result is written to vec
+ *
+ * Returns:
+ * dest if not NULL, vec otherwise
+ */
+vec2_t vec2_negate(vec2_t vec, vec2_t dest);
+
+/*
+ * vec2_scale
+ * Multiplies the components of a vec2_t by a scalar value
+ *
+ * Params:
+ * vec - vec2_t to scale
+ * val - Numeric value to scale by
+ * dest - Optional, vec2_t receiving operation result. If NULL, result is written to vec
+ *
+ * Returns:
+ * dest if not NULL, vec otherwise
+ */
+vec2_t vec2_scale(vec2_t vec, double val, vec2_t dest);
+
+/*
+ * vec2_normalize
+ * Generates a unit vector of the same direction as the provided vec2
+ * If vector length is 0, returns [0, 0]
+ *
+ * Params:
+ * vec - vec2_t to normalize
+ * dest - Optional, vec2_t receiving operation result. If NULL, result is written to vec
+ *
+ * Returns:
+ * dest if not NULL, vec otherwise
+ */
+vec2_t vec2_normalize(vec2_t vec, vec2_t dest);
+
+/*
+ * vec2_length
+ * Caclulates the length of a vec2
+ *
+ * Params:
+ * vec - vec2_t to calculate length of
+ *
+ * Returns:
+ * Length of vec
+ */
+double vec2_length(vec2_t vec);
+
+/*
+ * vec2_dot
+ * Caclulates the dot product of two vec2s
+ *
+ * Params:
+ * vec - vec2, first operand
+ * vec2 - vec2, second operand
+ *
+ * Returns:
+ * Dot product of vec and vec2
+ */
+double vec2_dot(vec2_t vec, vec2_t vec2);
+
+/*
+ * vec2_direction
+ * Generates a unit vector pointing from one vector to another
+ *
+ * Params:
+ * vec - origin vec2
+ * vec2 - vec2_t to point to
+ * dest - Optional, vec2_t receiving operation result. If NULL, result is written to vec
+ *
+ * Returns:
+ * dest if not NULL, vec otherwise
+ */
+vec2_t vec2_direction (vec2_t vec, vec2_t vec2, vec2_t dest);
+
+/*
+ * vec2_lerp
+ * Performs a linear interpolation between two vec2
+ *
+ * Params:
+ * vec - vec2, first vector
+ * vec2 - vec2, second vector
+ * lerp - interpolation amount between the two inputs
+ * dest - Optional, vec2_t receiving operation result. If NULL, result is written to vec
+ *
+ * Returns:
+ * dest if not NULL, vec otherwise
+ */
+vec2_t vec2_lerp(vec2_t vec, vec2_t vec2, double lerp, vec2_t dest);
+
+/*
+ * vec2_dist
+ * Calculates the euclidian distance between two vec2
+ *
+ * Params:
+ * vec - vec2, first vector
+ * vec2 - vec2, second vector
+ *
+ * Returns:
+ * distance between vec and vec2
+ */
+double vec2_dist(vec2_t vec, vec2_t vec2);
+
+/*
+ * vec2_str
+ * Writes a string representation of a vector
+ *
+ * Params:
+ * vec - vec2_t to represent as a string
+ * buffer - char * to store the results
+ */
+void vec2_str(vec2_t vec, char *buffer);
 
 /*
  * vec3_t - 3 Dimensional Vector
@@ -250,6 +427,182 @@ vec3_t vec3_unproject(vec3_t vec, mat4_t view, mat4_t proj, vec4_t viewport, vec
  * buffer - char * to store the results
  */
 void vec3_str(vec3_t vec, char *buffer);
+
+/*
+ * vec4_t - 4 Dimensional Vector
+ */
+
+/*
+ * vec4_create
+ * Creates a new instance of a vec4_t
+ *
+ * Params:
+ * vec - Optional, vec4_t containing values to initialize with. If NULL, the 
+ * vector will be initialized with zeroes.
+ *
+ * Returns:
+ * New vec4
+ */
+vec4_t vec4_create(vec4_t vec);
+
+/*
+ * vec4_set
+ * Copies the values of one vec4_t to another
+ *
+ * Params:
+ * vec - vec4_t containing values to copy
+ * dest - vec4_t receiving copied values
+ *
+ * Returns:
+ * dest
+ */
+vec4_t vec4_set(vec4_t vec, vec4_t dest);
+
+/*
+ * vec4_add
+ * Performs a vector addition
+ *
+ * Params:
+ * vec - vec4, first operand
+ * vec2 - vec4, second operand
+ * dest - Optional, vec4_t receiving operation result. If NULL, result is written to vec
+ *
+ * Returns:
+ * dest if not NULL, vec otherwise
+ */
+vec4_t vec4_add(vec4_t vec, vec4_t vec2, vec4_t dest);
+
+/*
+ * vec4_subtract
+ * Performs a vector subtraction
+ *
+ * Params:
+ * vec - vec4, first operand
+ * vec2 - vec4, second operand
+ * dest - Optional, vec4_t receiving operation result. If NULL, result is written to vec
+ *
+ * Returns:
+ * dest if not NULL, vec otherwise
+ */
+vec4_t vec4_subtract(vec4_t vec, vec4_t vec2, vec4_t dest);
+
+/*
+ * vec4_negate
+ * Negates the components of a vec4
+ *
+ * Params:
+ * vec - vec4_t to negate
+ * dest - Optional, vec4_t receiving operation result. If NULL, result is written to vec
+ *
+ * Returns:
+ * dest if not NULL, vec otherwise
+ */
+vec4_t vec4_negate(vec4_t vec, vec4_t dest);
+
+/*
+ * vec4_scale
+ * Multiplies the components of a vec4_t by a scalar value
+ *
+ * Params:
+ * vec - vec4_t to scale
+ * val - Numeric value to scale by
+ * dest - Optional, vec4_t receiving operation result. If NULL, result is written to vec
+ *
+ * Returns:
+ * dest if not NULL, vec otherwise
+ */
+vec4_t vec4_scale(vec4_t vec, double val, vec4_t dest);
+
+/*
+ * vec4_normalize
+ * Generates a unit vector of the same direction as the provided vec4
+ * If vector length is 0, returns [0, 0, 0, 0]
+ *
+ * Params:
+ * vec - vec4_t to normalize
+ * dest - Optional, vec4_t receiving operation result. If NULL, result is written to vec
+ *
+ * Returns:
+ * dest if not NULL, vec otherwise
+ */
+vec4_t vec4_normalize(vec4_t vec, vec4_t dest);
+
+/*
+ * vec4_length
+ * Caclulates the length of a vec4
+ *
+ * Params:
+ * vec - vec4_t to calculate length of
+ *
+ * Returns:
+ * Length of vec
+ */
+double vec4_length(vec4_t vec);
+
+/*
+ * vec4_dot
+ * Caclulates the dot product of two vec4s
+ *
+ * Params:
+ * vec - vec4, first operand
+ * vec2 - vec4, second operand
+ *
+ * Returns:
+ * Dot product of vec and vec2
+ */
+double vec4_dot(vec4_t vec, vec4_t vec2);
+
+/*
+ * vec4_direction
+ * Generates a unit vector pointing from one vector to another
+ *
+ * Params:
+ * vec - origin vec4
+ * vec2 - vec4_t to point to
+ * dest - Optional, vec4_t receiving operation result. If NULL, result is written to vec
+ *
+ * Returns:
+ * dest if not NULL, vec otherwise
+ */
+vec4_t vec4_direction (vec4_t vec, vec4_t vec2, vec4_t dest);
+
+/*
+ * vec4_lerp
+ * Performs a linear interpolation between two vec4
+ *
+ * Params:
+ * vec - vec4, first vector
+ * vec2 - vec4, second vector
+ * lerp - interpolation amount between the two inputs
+ * dest - Optional, vec4_t receiving operation result. If NULL, result is written to vec
+ *
+ * Returns:
+ * dest if not NULL, vec otherwise
+ */
+vec4_t vec4_lerp(vec4_t vec, vec4_t vec2, double lerp, vec4_t dest);
+
+/*
+ * vec4_dist
+ * Calculates the euclidian distance between two vec4
+ *
+ * Params:
+ * vec - vec4, first vector
+ * vec2 - vec4, second vector
+ *
+ * Returns:
+ * distance between vec and vec2
+ */
+double vec4_dist(vec4_t vec, vec4_t vec2);
+
+/*
+ * vec4_str
+ * Writes a string representation of a vector
+ *
+ * Params:
+ * vec - vec4_t to represent as a string
+ * buffer - char * to store the results
+ */
+void vec4_str(vec4_t vec, char *buffer);
 
 /*
  * mat3_t - 3x3 Matrix

--- a/gl-matrix.h
+++ b/gl-matrix.h
@@ -30,12 +30,14 @@ extern "C" {
                               (GL_MATRIX_MINOR_VERSION << 8) | \
                               (GL_MATRIX_MICRO_VERSION))
 
-typedef double *vec2_t;
-typedef double *vec3_t;
-typedef double *vec4_t;
-typedef double *mat3_t;
-typedef double *mat4_t;
-typedef double *quat_t;
+typedef float numeric_t;
+
+typedef numeric_t *vec2_t;
+typedef numeric_t *vec3_t;
+typedef numeric_t *vec4_t;
+typedef numeric_t *mat3_t;
+typedef numeric_t *mat4_t;
+typedef numeric_t *quat_t;
 
 /*
  * vec2_t - 2 Dimensional Vector
@@ -120,7 +122,7 @@ vec2_t vec2_negate(vec2_t vec, vec2_t dest);
  * Returns:
  * dest if not NULL, vec otherwise
  */
-vec2_t vec2_scale(vec2_t vec, double val, vec2_t dest);
+vec2_t vec2_scale(vec2_t vec, numeric_t val, vec2_t dest);
 
 /*
  * vec2_normalize
@@ -146,7 +148,7 @@ vec2_t vec2_normalize(vec2_t vec, vec2_t dest);
  * Returns:
  * Length of vec
  */
-double vec2_length(vec2_t vec);
+numeric_t vec2_length(vec2_t vec);
 
 /*
  * vec2_dot
@@ -159,7 +161,7 @@ double vec2_length(vec2_t vec);
  * Returns:
  * Dot product of vec and vec2
  */
-double vec2_dot(vec2_t vec, vec2_t vec2);
+numeric_t vec2_dot(vec2_t vec, vec2_t vec2);
 
 /*
  * vec2_direction
@@ -188,7 +190,7 @@ vec2_t vec2_direction (vec2_t vec, vec2_t vec2, vec2_t dest);
  * Returns:
  * dest if not NULL, vec otherwise
  */
-vec2_t vec2_lerp(vec2_t vec, vec2_t vec2, double lerp, vec2_t dest);
+vec2_t vec2_lerp(vec2_t vec, vec2_t vec2, numeric_t lerp, vec2_t dest);
 
 /*
  * vec2_dist
@@ -201,7 +203,7 @@ vec2_t vec2_lerp(vec2_t vec, vec2_t vec2, double lerp, vec2_t dest);
  * Returns:
  * distance between vec and vec2
  */
-double vec2_dist(vec2_t vec, vec2_t vec2);
+numeric_t vec2_dist(vec2_t vec, vec2_t vec2);
 
 /*
  * vec2_str
@@ -310,7 +312,7 @@ vec3_t vec3_negate(vec3_t vec, vec3_t dest);
  * Returns:
  * dest if not NULL, vec otherwise
  */
-vec3_t vec3_scale(vec3_t vec, double val, vec3_t dest);
+vec3_t vec3_scale(vec3_t vec, numeric_t val, vec3_t dest);
 
 /*
  * vec3_normalize
@@ -350,7 +352,7 @@ vec3_t vec3_cross (vec3_t vec, vec3_t vec2, vec3_t dest);
  * Returns:
  * Length of vec
  */
-double vec3_length(vec3_t vec);
+numeric_t vec3_length(vec3_t vec);
 
 /*
  * vec3_dot
@@ -363,7 +365,7 @@ double vec3_length(vec3_t vec);
  * Returns:
  * Dot product of vec and vec2
  */
-double vec3_dot(vec3_t vec, vec3_t vec2);
+numeric_t vec3_dot(vec3_t vec, vec3_t vec2);
 
 /*
  * vec3_direction
@@ -393,7 +395,7 @@ vec3_t vec3_direction (vec3_t vec, vec3_t vec2, vec3_t dest);
  * dest if not NULL, vec otherwise
  */
 
-vec3_t vec3_lerp(vec3_t vec, vec3_t vec2, double lerp, vec3_t dest);
+vec3_t vec3_lerp(vec3_t vec, vec3_t vec2, numeric_t lerp, vec3_t dest);
 
 /*
  * vec3_dist
@@ -406,7 +408,7 @@ vec3_t vec3_lerp(vec3_t vec, vec3_t vec2, double lerp, vec3_t dest);
  * Returns:
  * distance between vec and vec2
  */
-double vec3_dist(vec3_t vec, vec3_t vec2);
+numeric_t vec3_dist(vec3_t vec, vec3_t vec2);
 
 /*
  * vec3_unproject
@@ -519,7 +521,7 @@ vec4_t vec4_negate(vec4_t vec, vec4_t dest);
  * Returns:
  * dest if not NULL, vec otherwise
  */
-vec4_t vec4_scale(vec4_t vec, double val, vec4_t dest);
+vec4_t vec4_scale(vec4_t vec, numeric_t val, vec4_t dest);
 
 /*
  * vec4_normalize
@@ -545,7 +547,7 @@ vec4_t vec4_normalize(vec4_t vec, vec4_t dest);
  * Returns:
  * Length of vec
  */
-double vec4_length(vec4_t vec);
+numeric_t vec4_length(vec4_t vec);
 
 /*
  * vec4_dot
@@ -558,7 +560,7 @@ double vec4_length(vec4_t vec);
  * Returns:
  * Dot product of vec and vec2
  */
-double vec4_dot(vec4_t vec, vec4_t vec2);
+numeric_t vec4_dot(vec4_t vec, vec4_t vec2);
 
 /*
  * vec4_direction
@@ -587,7 +589,7 @@ vec4_t vec4_direction (vec4_t vec, vec4_t vec2, vec4_t dest);
  * Returns:
  * dest if not NULL, vec otherwise
  */
-vec4_t vec4_lerp(vec4_t vec, vec4_t vec2, double lerp, vec4_t dest);
+vec4_t vec4_lerp(vec4_t vec, vec4_t vec2, numeric_t lerp, vec4_t dest);
 
 /*
  * vec4_dist
@@ -600,7 +602,7 @@ vec4_t vec4_lerp(vec4_t vec, vec4_t vec2, double lerp, vec4_t dest);
  * Returns:
  * distance between vec and vec2
  */
-double vec4_dist(vec4_t vec, vec4_t vec2);
+numeric_t vec4_dist(vec4_t vec, vec4_t vec2);
 
 /*
  * vec4_str
@@ -754,7 +756,7 @@ mat4_t mat4_transpose(mat4_t mat, mat4_t dest);
  * Returns:
  * determinant of mat
  */
-double mat4_determinant(mat4_t mat);
+numeric_t mat4_determinant(mat4_t mat);
 
 /*
  * mat4_inverse
@@ -894,7 +896,7 @@ mat4_t mat4_scale(mat4_t mat, vec3_t vec, mat4_t dest);
  * Returns:
  * dest if not NULL, mat otherwise
  */
-mat4_t mat4_rotate(mat4_t mat, double angle, vec3_t axis, mat4_t dest);
+mat4_t mat4_rotate(mat4_t mat, numeric_t angle, vec3_t axis, mat4_t dest);
 
 /*
  * mat4_rotateX
@@ -908,7 +910,7 @@ mat4_t mat4_rotate(mat4_t mat, double angle, vec3_t axis, mat4_t dest);
  * Returns:
  * dest if not NULL, mat otherwise
  */
-mat4_t mat4_rotateX(mat4_t mat, double angle, mat4_t dest);
+mat4_t mat4_rotateX(mat4_t mat, numeric_t angle, mat4_t dest);
 
 /*
  * mat4_rotateY
@@ -922,7 +924,7 @@ mat4_t mat4_rotateX(mat4_t mat, double angle, mat4_t dest);
  * Returns:
  * dest if not NULL, mat otherwise
  */
-mat4_t mat4_rotateY(mat4_t mat, double angle, mat4_t dest);
+mat4_t mat4_rotateY(mat4_t mat, numeric_t angle, mat4_t dest);
 
 /*
  * mat4_rotateZ
@@ -936,7 +938,7 @@ mat4_t mat4_rotateY(mat4_t mat, double angle, mat4_t dest);
  * Returns:
  * dest if not NULL, mat otherwise
  */
-mat4_t mat4_rotateZ(mat4_t mat, double angle, mat4_t dest);
+mat4_t mat4_rotateZ(mat4_t mat, numeric_t angle, mat4_t dest);
 
 /*
  * mat4_frustum
@@ -951,7 +953,7 @@ mat4_t mat4_rotateZ(mat4_t mat, double angle, mat4_t dest);
  * Returns:
  * dest if not NULL, a new mat4_t otherwise
  */
-mat4_t mat4_frustum(double left, double right, double bottom, double top, double near, double far, mat4_t dest);
+mat4_t mat4_frustum(numeric_t left, numeric_t right, numeric_t bottom, numeric_t top, numeric_t near, numeric_t far, mat4_t dest);
 
 /*
  * mat4_perspective
@@ -966,7 +968,7 @@ mat4_t mat4_frustum(double left, double right, double bottom, double top, double
  * Returns:
  * dest if not NULL, a new mat4_t otherwise
  */
-mat4_t mat4_perspective(double fovy, double aspect, double near, double far, mat4_t dest);
+mat4_t mat4_perspective(numeric_t fovy, numeric_t aspect, numeric_t near, numeric_t far, mat4_t dest);
 
 /*
  * mat4_ortho
@@ -981,7 +983,7 @@ mat4_t mat4_perspective(double fovy, double aspect, double near, double far, mat
  * Returns:
  * dest if not NULL, a new mat4_t otherwise
  */
-mat4_t mat4_ortho(double left, double right, double bottom, double top, double near, double far, mat4_t dest);
+mat4_t mat4_ortho(numeric_t left, numeric_t right, numeric_t bottom, numeric_t top, numeric_t near, numeric_t far, mat4_t dest);
 
 /*
  * mat4_lookAt
@@ -1082,7 +1084,7 @@ quat_t quat_calculateW(quat_t quat, quat_t dest);
  *
  * @return {number} Dot product of quat and quat2
  */
-double quat_dot(quat_t quat, quat_t quat2);
+numeric_t quat_dot(quat_t quat, quat_t quat2);
 
 /*
  * quat_inverse
@@ -1120,7 +1122,7 @@ quat_t quat_conjugate(quat_t quat, quat_t dest);
  * Returns:
  * Length of quat
  */
-double quat_length(quat_t quat);
+numeric_t quat_length(quat_t quat);
 
 /*
  * quat_normalize
@@ -1203,7 +1205,7 @@ quat_t quat_toMat4(quat_t quat, mat4_t dest);
  * Returns:
  * dest if not NULL, quat otherwise
  */
-quat_t quat_slerp(quat_t quat, quat_t quat2, double slerp, quat_t dest);
+quat_t quat_slerp(quat_t quat, quat_t quat2, numeric_t slerp, quat_t dest);
 
 /*
  * quat_str

--- a/gl-matrix.h
+++ b/gl-matrix.h
@@ -1,3 +1,11 @@
+/*
+https://github.com/wernsey/gl-matrix.c
+This was forked from https://github.com/coreh/gl-matrix.c
+with some additions for vec2_t and vec4_t types.
+
+This is a fairly straightforward port of gl-matrix.js (https://github.com/toji/gl-matrix)
+from JavaScript to C.
+*/
 #ifndef GL_MATRIX_H
 #define GL_MATRIX_H
 

--- a/gl-matrix.h
+++ b/gl-matrix.h
@@ -475,7 +475,7 @@ mat4_t mat4_multiply(mat4_t mat, mat4_t mat2, mat4_t dest);
  * Returns:
  * dest if not NULL, vec otherwise
  */
-mat4_t mat4_multiplyVec3(mat4_t mat, vec3_t vec, mat4_t dest);
+vec3_t mat4_multiplyVec3(mat4_t mat, vec3_t vec, vec3_t dest);
 
 /*
  * mat4_multiplyVec4
@@ -489,7 +489,7 @@ mat4_t mat4_multiplyVec3(mat4_t mat, vec3_t vec, mat4_t dest);
  * Returns:
  * dest if not NULL, vec otherwise
  */
-mat4_t mat4_multiplyVec4(mat4_t mat, vec4_t vec, mat4_t dest);
+vec4_t mat4_multiplyVec4(mat4_t mat, vec4_t vec, vec4_t dest);
 
 /*
  * mat4_translate

--- a/gl-matrix.h
+++ b/gl-matrix.h
@@ -70,6 +70,30 @@ vec2_t vec2_create(vec2_t vec);
 vec2_t vec2_set(vec2_t vec, vec2_t dest);
 
 /*
+ * vec2_zeroes
+ * Sets the value of a vec2_t to {0,0}
+ *
+ * Params:
+ * vec - vec2_t to set
+ *
+ * Returns:
+ * vec
+ */
+vec2_t vec2_zeroes(vec2_t vec);
+
+/*
+ * vec2_ones
+ * Sets the value of a vec2_t to {1,1}
+ *
+ * Params:
+ * vec - vec2_t to set
+ *
+ * Returns:
+ * vec
+ */
+vec2_t vec2_ones(vec2_t vec);
+
+/*
  * vec2_add
  * Performs a vector addition
  *
@@ -244,6 +268,30 @@ vec3_t vec3_create(vec3_t vec);
  * dest
  */
 vec3_t vec3_set(vec3_t vec, vec3_t dest);
+
+/*
+ * vec3_zeroes
+ * Sets the value of a vec3_t to {0,0,0}
+ *
+ * Params:
+ * vec - vec3_t to set
+ *
+ * Returns:
+ * vec
+ */
+vec3_t vec3_zeroes(vec3_t vec);
+
+/*
+ * vec3_ones
+ * Sets the value of a vec3_t to {1,1,1}
+ *
+ * Params:
+ * vec - vec3_t to set
+ *
+ * Returns:
+ * vec
+ */
+vec3_t vec3_ones(vec3_t vec);
 
 /*
  * vec3_add
@@ -467,6 +515,30 @@ vec4_t vec4_create(vec4_t vec);
  * dest
  */
 vec4_t vec4_set(vec4_t vec, vec4_t dest);
+
+/*
+ * vec4_zeroes
+ * Sets the value of a vec4_t to {0,0,0,0}
+ *
+ * Params:
+ * vec - vec4_t to set
+ *
+ * Returns:
+ * vec
+ */
+vec4_t vec4_zeroes(vec4_t vec);
+
+/*
+ * vec4_ones
+ * Sets the value of a vec4_t to {1,1,1,1}
+ *
+ * Params:
+ * vec - vec4_t to set
+ *
+ * Returns:
+ * vec
+ */
+vec4_t vec4_ones(vec4_t vec);
 
 /*
  * vec4_add
@@ -974,7 +1046,7 @@ mat4_t mat4_frustum(numeric_t left, numeric_t right, numeric_t bottom, numeric_t
  * Generates a perspective projection matrix with the given bounds
  *
  * Params:
- * fovy - scalar, vertical field of view
+ * fovy - scalar, vertical field of view (in degrees)
  * aspect - scalar, aspect ratio. typically viewport width/height
  * near, far - scalar, near and far bounds of the frustum
  * dest - Optional, mat4_t frustum matrix will be written into

--- a/gl-matrix.h
+++ b/gl-matrix.h
@@ -13,11 +13,11 @@ from JavaScript to C.
 extern "C" {
 #endif
 
-/* 
+/*
  * gl-matrix.c - High performance matrix and vector operations for OpenGL
  * Version 1.2.3
  */
- 
+
 #define GL_MATRIX_MAJOR_VERSION 1
 #define GL_MATRIX_MINOR_VERSION 2
 #define GL_MATRIX_MICRO_VERSION 3
@@ -48,7 +48,7 @@ typedef numeric_t *quat_t;
  * Creates a new instance of a vec2_t
  *
  * Params:
- * vec - Optional, vec2_t containing values to initialize with. If NULL, the 
+ * vec - Optional, vec2_t containing values to initialize with. If NULL, the
  * vector will be initialized with zeroes.
  *
  * Returns:
@@ -224,7 +224,7 @@ void vec2_str(vec2_t vec, char *buffer);
  * Creates a new instance of a vec3_t
  *
  * Params:
- * vec - Optional, vec3_t containing values to initialize with. If NULL, the 
+ * vec - Optional, vec3_t containing values to initialize with. If NULL, the
  * vector will be initialized with zeroes.
  *
  * Returns:
@@ -413,7 +413,7 @@ numeric_t vec3_dist(vec3_t vec, vec3_t vec2);
 /*
  * vec3_unproject
  * Projects the specified vec3_t from screen space into object space
- * Based on Mesa gluUnProject implementation at: 
+ * Based on Mesa gluUnProject implementation at:
  * http://webcvs.freedesktop.org/mesa/Mesa/src/glu/mesa/project.c?revision=1.4&view=markup
  *
  * Params:
@@ -447,7 +447,7 @@ void vec3_str(vec3_t vec, char *buffer);
  * Creates a new instance of a vec4_t
  *
  * Params:
- * vec - Optional, vec4_t containing values to initialize with. If NULL, the 
+ * vec - Optional, vec4_t containing values to initialize with. If NULL, the
  * vector will be initialized with zeroes.
  *
  * Returns:
@@ -688,7 +688,7 @@ mat4_t mat3_toMat4(mat3_t mat, mat4_t dest);
  *
  * Params:
  * mat - mat3_t to represent as a string
- * buffer - char * to store the results 
+ * buffer - char * to store the results
  */
 void mat3_str(mat3_t mat, char *buffer);
 
@@ -732,7 +732,7 @@ mat4_t mat4_set(mat4_t mat, mat4_t dest);
  * dest
  */
 mat4_t mat4_identity(mat4_t dest);
-     
+
 /*
  * mat4_transpose
  * Transposes a mat4_t (flips the values over the diagonal)
@@ -883,6 +883,20 @@ mat4_t mat4_translate(mat4_t mat, vec3_t vec, mat4_t dest);
 mat4_t mat4_scale(mat4_t mat, vec3_t vec, mat4_t dest);
 
 /*
+ * mat4_scale_scalar
+ * Scales a matrix by the given scalar
+ *
+ * Params:
+ * mat - mat4_t to scale
+ * scalar - scalar specifying the scale for each axis
+ * dest - Optional, mat4_t receiving operation result. If NULL, result is written to mat
+ *
+ * Returns:
+ * dest if not NULL, mat otherwise
+ */
+mat4_t mat4_scale_scalar(mat4_t mat, numeric_t scalar, mat4_t dest);
+
+/*
  * mat4_rotate
  * Rotates a matrix by the given angle around the specified axis
  * If rotating around a primary axis (X,Y,Z) one of the specialized rotation functions should be used instead for performance
@@ -890,7 +904,7 @@ mat4_t mat4_scale(mat4_t mat, vec3_t vec, mat4_t dest);
  * Params:
  * mat - mat4_t to rotate
  * angle - angle (in radians) to rotate
- * axis - vec3_t representing the axis to rotate around 
+ * axis - vec3_t representing the axis to rotate around
  * dest - Optional, mat4_t receiving operation result. If NULL, result is written to mat
  *
  * Returns:
@@ -1032,7 +1046,7 @@ mat4_t mat4_fromRotationTranslation(quat_t quat, vec3_t vec, mat4_t dest);
 void mat4_str(mat4_t mat, char *buffer);
 
 /*
- * quat - Quaternions 
+ * quat - Quaternions
  */
 
 /*
@@ -1063,8 +1077,8 @@ quat_t quat_set(quat_t quat, quat_t dest);
 /*
  * quat_calculateW
  * Calculates the W component of a quat_t from the X, Y, and Z components.
- * Assumes that quaternion is 1 unit in length. 
- * Any existing W component will be ignored. 
+ * Assumes that quaternion is 1 unit in length.
+ * Any existing W component will be ignored.
  *
  * Params:
  * quat - quat_t to calculate W component of
@@ -1206,6 +1220,25 @@ quat_t quat_toMat4(quat_t quat, mat4_t dest);
  * dest if not NULL, quat otherwise
  */
 quat_t quat_slerp(quat_t quat, quat_t quat2, numeric_t slerp, quat_t dest);
+
+/*
+ * quat_rotate
+ * Rotates a point around a quaternion by applying the formula
+ *
+ *    r = q.p.q*
+ *
+ * where q is the quaternion, q* is its conjugate, and p is the
+ * point to be rotated.
+ *
+ * Params:
+ * quat - quat_t, first quaternion
+ * p - vec3_t, the point to rotate
+ * dest - Optional, quat_t receiving operation result. If NULL, result is written to quat
+ *
+ * Returns:
+ * dest if not NULL, quat otherwise
+ */
+quat_t quat_rotate(quat_t quat, vec3_t p, quat_t dest);
 
 /*
  * quat_str

--- a/gl-matrix.h
+++ b/gl-matrix.h
@@ -1108,6 +1108,23 @@ mat4_t mat4_lookAt(vec3_t eye, vec3_t center, vec3_t up, mat4_t dest);
 mat4_t mat4_fromRotationTranslation(quat_t quat, vec3_t vec, mat4_t dest);
 
 /*
+ * mat4_alignVectors
+ * Creates a matrix that will rotate one vector to point into the direction of another.
+ *
+ * If the resulting matrix is applied to the source vector it will point in the
+ * direction of the target vector.
+ *
+ * Params:
+ * source - Source orientation
+ * target - Target orientation
+ * dest - mat4_t receiving operation result.
+ *
+ * Returns:
+ * dest
+ */
+mat4_t mat4_alignVectors(vec3_t source, vec3_t target, mat4_t dest);
+
+/*
  * mat4_str
  * Writes a string representation of a mat4
  *
@@ -1292,6 +1309,20 @@ quat_t quat_toMat4(quat_t quat, mat4_t dest);
  * dest if not NULL, quat otherwise
  */
 quat_t quat_slerp(quat_t quat, quat_t quat2, numeric_t slerp, quat_t dest);
+
+/*
+ * quat_axisFromAngle
+ * Creates a quaternion to rotate objects around a specific axis by a specific angle
+ *
+ * Params:
+ * axis - The axis to rotate around
+ * angle - The angle to rotate
+ * dest - quat_t receiving operation result
+ *
+ * Returns:
+ * dest
+ */
+quat_t quat_axisFromAngle(vec3_t axis, numeric_t angle, quat_t dest);
 
 /*
  * quat_rotate

--- a/gl-matrix.h
+++ b/gl-matrix.h
@@ -755,6 +755,20 @@ mat3_t mat3_transpose(mat3_t mat, mat3_t dest);
 mat4_t mat3_toMat4(mat3_t mat, mat4_t dest);
 
 /*
+ * mat3_multiplyVec3
+ * Transforms a vec3_t with the given matrix
+ *
+ * Params:
+ * mat - mat3_t to transform the vector with
+ * vec - vec3_t to transform
+ * dest - Optional, vec3_t receiving operation result. If NULL, result is written to vec
+ *
+ * Returns:
+ * dest if not NULL, vec otherwise
+ */
+vec3_t mat3_multiplyVec3(mat3_t mat, vec3_t vec, vec3_t dest);
+
+/*
  * mat3_str
  * Writes a string representation of a mat3
  *

--- a/mat3.c
+++ b/mat3.c
@@ -4,7 +4,7 @@
 #include "gl-matrix.h"
 
 mat3_t mat3_create(mat3_t mat) {
-    mat3_t dest = calloc(sizeof(double), 9);
+    mat3_t dest = calloc(9, sizeof(double));
 
     if (mat) {
         dest[0] = mat[0];

--- a/mat3.c
+++ b/mat3.c
@@ -4,7 +4,7 @@
 #include "gl-matrix.h"
 
 mat3_t mat3_create(mat3_t mat) {
-    mat3_t dest = calloc(9, sizeof(double));
+    mat3_t dest = calloc(9, sizeof(numeric_t));
 
     if (mat) {
         dest[0] = mat[0];
@@ -51,7 +51,7 @@ mat3_t mat3_identity(mat3_t dest) {
 mat3_t mat3_transpose(mat3_t mat, mat3_t dest) {
     // If we are transposing ourselves we can skip a few steps but have to cache some values
     if (!dest || mat == dest) {
-        double a01 = mat[1], a02 = mat[2],
+        numeric_t a01 = mat[1], a02 = mat[2],
             a12 = mat[5];
 
         mat[1] = mat[3];

--- a/mat3.c
+++ b/mat3.c
@@ -100,3 +100,15 @@ mat4_t mat3_toMat4(mat3_t mat, mat4_t dest) {
 
     return dest;
 }
+
+vec3_t mat3_multiplyVec3(mat3_t mat, vec3_t vec, vec3_t dest) {
+    if (!dest) { dest = vec; }
+
+    numeric_t x = vec[0], y = vec[1], z = vec[2];
+
+    dest[0] = mat[0] * x + mat[3] * y + mat[6] * z;
+    dest[1] = mat[1] * x + mat[4] * y + mat[7] * z;
+    dest[2] = mat[2] * x + mat[5] * y + mat[8] * z;
+
+    return dest;
+}

--- a/mat4.c
+++ b/mat4.c
@@ -4,7 +4,7 @@
 #include "gl-matrix.h"
 
 mat4_t mat4_create(mat4_t mat) {
-    mat4_t dest = calloc(sizeof(double), 16);
+    mat4_t dest = calloc(16, sizeof(double));
 
     if (mat) {
         dest[0] = mat[0];

--- a/mat4.c
+++ b/mat4.c
@@ -278,7 +278,7 @@ mat4_t mat4_multiply(mat4_t mat, mat4_t mat2, mat4_t dest) {
     return dest;
 }
 
-mat4_t mat4_multiplyVec3(mat4_t mat, vec3_t vec, mat4_t dest) {
+vec3_t mat4_multiplyVec3(mat4_t mat, vec3_t vec, vec3_t dest) {
     if (!dest) { dest = vec; }
 
     double x = vec[0], y = vec[1], z = vec[2];
@@ -290,7 +290,7 @@ mat4_t mat4_multiplyVec3(mat4_t mat, vec3_t vec, mat4_t dest) {
     return dest;
 }
 
-mat4_t mat4_multiplyVec4(mat4_t mat, vec4_t vec, mat4_t dest) {
+vec4_t mat4_multiplyVec4(mat4_t mat, vec4_t vec, vec4_t dest) {
     if (!dest) { dest = vec; }
 
     double x = vec[0], y = vec[1], z = vec[2], w = vec[3];

--- a/mat4.c
+++ b/mat4.c
@@ -4,7 +4,7 @@
 #include "gl-matrix.h"
 
 mat4_t mat4_create(mat4_t mat) {
-    mat4_t dest = calloc(16, sizeof(double));
+    mat4_t dest = calloc(16, sizeof(numeric_t));
 
     if (mat) {
         dest[0] = mat[0];
@@ -72,7 +72,7 @@ mat4_t mat4_identity(mat4_t dest) {
 mat4_t mat4_transpose(mat4_t mat, mat4_t dest) {
     // If we are transposing ourselves we can skip a few steps but have to cache some values
     if (!dest || mat == dest) {
-        double a01 = mat[1], a02 = mat[2], a03 = mat[3],
+        numeric_t a01 = mat[1], a02 = mat[2], a03 = mat[3],
             a12 = mat[6], a13 = mat[7],
             a23 = mat[11];
 
@@ -110,9 +110,9 @@ mat4_t mat4_transpose(mat4_t mat, mat4_t dest) {
     return dest;
 }
 
-double mat4_determinant(mat4_t mat) {
+numeric_t mat4_determinant(mat4_t mat) {
     // Cache the matrix values (makes for huge speed increases!)
-    double a00 = mat[0], a01 = mat[1], a02 = mat[2], a03 = mat[3],
+    numeric_t a00 = mat[0], a01 = mat[1], a02 = mat[2], a03 = mat[3],
         a10 = mat[4], a11 = mat[5], a12 = mat[6], a13 = mat[7],
         a20 = mat[8], a21 = mat[9], a22 = mat[10], a23 = mat[11],
         a30 = mat[12], a31 = mat[13], a32 = mat[14], a33 = mat[15];
@@ -129,7 +129,7 @@ mat4_t mat4_inverse(mat4_t mat, mat4_t dest) {
     if (!dest) { dest = mat; }
 
     // Cache the matrix values (makes for huge speed increases!)
-    double a00 = mat[0], a01 = mat[1], a02 = mat[2], a03 = mat[3],
+    numeric_t a00 = mat[0], a01 = mat[1], a02 = mat[2], a03 = mat[3],
         a10 = mat[4], a11 = mat[5], a12 = mat[6], a13 = mat[7],
         a20 = mat[8], a21 = mat[9], a22 = mat[10], a23 = mat[11],
         a30 = mat[12], a31 = mat[13], a32 = mat[14], a33 = mat[15],
@@ -215,7 +215,7 @@ mat3_t mat4_toMat3(mat4_t mat, mat3_t dest) {
 
 mat3_t mat4_toInverseMat3(mat4_t mat, mat3_t dest) {
     // Cache the matrix values (makes for huge speed increases!)
-    double a00 = mat[0], a01 = mat[1], a02 = mat[2],
+    numeric_t a00 = mat[0], a01 = mat[1], a02 = mat[2],
         a10 = mat[4], a11 = mat[5], a12 = mat[6],
         a20 = mat[8], a21 = mat[9], a22 = mat[10],
 
@@ -248,7 +248,7 @@ mat4_t mat4_multiply(mat4_t mat, mat4_t mat2, mat4_t dest) {
     if (!dest) { dest = mat; }
 
     // Cache the matrix values (makes for huge speed increases!)
-    double a00 = mat[0], a01 = mat[1], a02 = mat[2], a03 = mat[3],
+    numeric_t a00 = mat[0], a01 = mat[1], a02 = mat[2], a03 = mat[3],
         a10 = mat[4], a11 = mat[5], a12 = mat[6], a13 = mat[7],
         a20 = mat[8], a21 = mat[9], a22 = mat[10], a23 = mat[11],
         a30 = mat[12], a31 = mat[13], a32 = mat[14], a33 = mat[15],
@@ -281,7 +281,7 @@ mat4_t mat4_multiply(mat4_t mat, mat4_t mat2, mat4_t dest) {
 vec3_t mat4_multiplyVec3(mat4_t mat, vec3_t vec, vec3_t dest) {
     if (!dest) { dest = vec; }
 
-    double x = vec[0], y = vec[1], z = vec[2];
+    numeric_t x = vec[0], y = vec[1], z = vec[2];
 
     dest[0] = mat[0] * x + mat[4] * y + mat[8] * z + mat[12];
     dest[1] = mat[1] * x + mat[5] * y + mat[9] * z + mat[13];
@@ -293,7 +293,7 @@ vec3_t mat4_multiplyVec3(mat4_t mat, vec3_t vec, vec3_t dest) {
 vec4_t mat4_multiplyVec4(mat4_t mat, vec4_t vec, vec4_t dest) {
     if (!dest) { dest = vec; }
 
-    double x = vec[0], y = vec[1], z = vec[2], w = vec[3];
+    numeric_t x = vec[0], y = vec[1], z = vec[2], w = vec[3];
 
     dest[0] = mat[0] * x + mat[4] * y + mat[8] * z + mat[12] * w;
     dest[1] = mat[1] * x + mat[5] * y + mat[9] * z + mat[13] * w;
@@ -304,7 +304,7 @@ vec4_t mat4_multiplyVec4(mat4_t mat, vec4_t vec, vec4_t dest) {
 }
 
 mat4_t mat4_translate(mat4_t mat, vec3_t vec, mat4_t dest) {
-    double x = vec[0], y = vec[1], z = vec[2],
+    numeric_t x = vec[0], y = vec[1], z = vec[2],
         a00, a01, a02, a03,
         a10, a11, a12, a13,
         a20, a21, a22, a23;
@@ -333,7 +333,7 @@ mat4_t mat4_translate(mat4_t mat, vec3_t vec, mat4_t dest) {
 }
 
 mat4_t mat4_scale(mat4_t mat, vec3_t vec, mat4_t dest) {
-    double x = vec[0], y = vec[1], z = vec[2];
+    numeric_t x = vec[0], y = vec[1], z = vec[2];
 
     if (!dest || mat == dest) {
         mat[0] *= x;
@@ -370,8 +370,8 @@ mat4_t mat4_scale(mat4_t mat, vec3_t vec, mat4_t dest) {
     return dest;
 }
 
-mat4_t mat4_rotate(mat4_t mat, double angle, vec3_t axis, mat4_t dest) {
-    double x = axis[0], y = axis[1], z = axis[2],
+mat4_t mat4_rotate(mat4_t mat, numeric_t angle, vec3_t axis, mat4_t dest) {
+    numeric_t x = axis[0], y = axis[1], z = axis[2],
         len = sqrt(x * x + y * y + z * z),
         s, c, t,
         a00, a01, a02, a03,
@@ -429,8 +429,8 @@ mat4_t mat4_rotate(mat4_t mat, double angle, vec3_t axis, mat4_t dest) {
     return dest;
 }
 
-mat4_t mat4_rotateX(mat4_t mat, double angle, mat4_t dest) {
-    double s = sin(angle),
+mat4_t mat4_rotateX(mat4_t mat, numeric_t angle, mat4_t dest) {
+    numeric_t s = sin(angle),
         c = cos(angle),
         a10 = mat[4],
         a11 = mat[5],
@@ -468,8 +468,8 @@ mat4_t mat4_rotateX(mat4_t mat, double angle, mat4_t dest) {
     return dest;
 }
 
-mat4_t mat4_rotateY(mat4_t mat, double angle, mat4_t dest) {
-    double s = sin(angle),
+mat4_t mat4_rotateY(mat4_t mat, numeric_t angle, mat4_t dest) {
+    numeric_t s = sin(angle),
         c = cos(angle),
         a00 = mat[0],
         a01 = mat[1],
@@ -507,8 +507,8 @@ mat4_t mat4_rotateY(mat4_t mat, double angle, mat4_t dest) {
     return dest;
 }
 
-mat4_t mat4_rotateZ(mat4_t mat, double angle, mat4_t dest) {
-    double s = sin(angle),
+mat4_t mat4_rotateZ(mat4_t mat, numeric_t angle, mat4_t dest) {
+    numeric_t s = sin(angle),
         c = cos(angle),
         a00 = mat[0],
         a01 = mat[1],
@@ -547,9 +547,9 @@ mat4_t mat4_rotateZ(mat4_t mat, double angle, mat4_t dest) {
     return dest;
 }
 
-mat4_t mat4_frustum(double left, double right, double bottom, double top, double near, double far, mat4_t dest) {
+mat4_t mat4_frustum(numeric_t left, numeric_t right, numeric_t bottom, numeric_t top, numeric_t near, numeric_t far, mat4_t dest) {
     if (!dest) { dest = mat4_create(NULL); }
-    double rl = (right - left),
+    numeric_t rl = (right - left),
         tb = (top - bottom),
         fn = (far - near);
     dest[0] = (near * 2) / rl;
@@ -571,15 +571,15 @@ mat4_t mat4_frustum(double left, double right, double bottom, double top, double
     return dest;
 }
 
-mat4_t mat4_perspective(double fovy, double aspect, double near, double far, mat4_t dest) {
-    double top = near * tan(fovy * 3.14159265358979323846 / 360.0),
+mat4_t mat4_perspective(numeric_t fovy, numeric_t aspect, numeric_t near, numeric_t far, mat4_t dest) {
+    numeric_t top = near * tan(fovy * 3.14159265358979323846 / 360.0),
         right = top * aspect;
     return mat4_frustum(-right, right, -top, top, near, far, dest);
 }
 
-mat4_t mat4_ortho(double left, double right, double bottom, double top, double near, double far, mat4_t dest) {
+mat4_t mat4_ortho(numeric_t left, numeric_t right, numeric_t bottom, numeric_t top, numeric_t near, numeric_t far, mat4_t dest) {
     if (!dest) { dest = mat4_create(NULL); }
-    double rl = (right - left),
+    numeric_t rl = (right - left),
         tb = (top - bottom),
         fn = (far - near);
     dest[0] = 2 / rl;
@@ -604,7 +604,7 @@ mat4_t mat4_ortho(double left, double right, double bottom, double top, double n
 mat4_t mat4_lookAt(vec3_t eye, vec3_t center, vec3_t up, mat4_t dest) {
     if (!dest) { dest = mat4_create(NULL); }
 
-    double x0, x1, x2, y0, y1, y2, z0, z1, z2, len,
+    numeric_t x0, x1, x2, y0, y1, y2, z0, z1, z2, len,
         eyex = eye[0],
         eyey = eye[1],
         eyez = eye[2],
@@ -687,7 +687,7 @@ mat4_t mat4_fromRotationTranslation(quat_t quat, vec3_t vec, mat4_t dest) {
     if (!dest) { dest = mat4_create(NULL); }
 
     // Quaternion math
-    double x = quat[0], y = quat[1], z = quat[2], w = quat[3],
+    numeric_t x = quat[0], y = quat[1], z = quat[2], w = quat[3],
         x2 = x + x,
         y2 = y + y,
         z2 = z + z,

--- a/mat4.c
+++ b/mat4.c
@@ -370,6 +370,42 @@ mat4_t mat4_scale(mat4_t mat, vec3_t vec, mat4_t dest) {
     return dest;
 }
 
+mat4_t mat4_scale_scalar(mat4_t mat, numeric_t scalar, mat4_t dest) {
+    if (!dest || mat == dest) {
+        mat[0] *= scalar;
+        mat[1] *= scalar;
+        mat[2] *= scalar;
+        mat[3] *= scalar;
+        mat[4] *= scalar;
+        mat[5] *= scalar;
+        mat[6] *= scalar;
+        mat[7] *= scalar;
+        mat[8] *= scalar;
+        mat[9] *= scalar;
+        mat[10] *= scalar;
+        mat[11] *= scalar;
+        return mat;
+    }
+
+    dest[0] = mat[0] * scalar;
+    dest[1] = mat[1] * scalar;
+    dest[2] = mat[2] * scalar;
+    dest[3] = mat[3] * scalar;
+    dest[4] = mat[4] * scalar;
+    dest[5] = mat[5] * scalar;
+    dest[6] = mat[6] * scalar;
+    dest[7] = mat[7] * scalar;
+    dest[8] = mat[8] * scalar;
+    dest[9] = mat[9] * scalar;
+    dest[10] = mat[10] * scalar;
+    dest[11] = mat[11] * scalar;
+    dest[12] = mat[12];
+    dest[13] = mat[13];
+    dest[14] = mat[14];
+    dest[15] = mat[15];
+    return dest;
+}
+
 mat4_t mat4_rotate(mat4_t mat, numeric_t angle, vec3_t axis, mat4_t dest) {
     numeric_t x = axis[0], y = axis[1], z = axis[2],
         len = sqrt(x * x + y * y + z * z),

--- a/quat.c
+++ b/quat.c
@@ -4,7 +4,7 @@
 #include "gl-matrix.h"
 
 quat_t quat_create(quat_t quat) {
-    quat_t dest = calloc(4, sizeof(double));
+    quat_t dest = calloc(4, sizeof(numeric_t));
 
     if (quat) {
         dest[0] = quat[0];
@@ -26,7 +26,7 @@ quat_t quat_set(quat_t quat, quat_t dest) {
 }
 
 quat_t quat_calculateW(quat_t quat, quat_t dest) {
-    double x = quat[0], y = quat[1], z = quat[2];
+    numeric_t x = quat[0], y = quat[1], z = quat[2];
 
     if (!dest || quat == dest) {
         quat[3] = -sqrt(fabs(1.0 - x * x - y * y - z * z));
@@ -39,12 +39,12 @@ quat_t quat_calculateW(quat_t quat, quat_t dest) {
     return dest;
 }
 
-double quat_dot(quat_t quat, quat_t quat2) {
+numeric_t quat_dot(quat_t quat, quat_t quat2) {
     return quat[0]*quat2[0] + quat[1]*quat2[1] + quat[2]*quat2[2] + quat[3]*quat2[3];
 }
 
 quat_t quat_inverse(quat_t quat, quat_t dest) {
-    double dot = quat_dot(quat,quat),
+    numeric_t dot = quat_dot(quat,quat),
         invDot = 1.0/dot;
     if(!dest || quat == dest) {
         quat[0] *= -invDot;
@@ -74,15 +74,15 @@ quat_t quat_conjugate(quat_t quat, quat_t dest) {
     return dest;
 }
 
-double quat_length(quat_t quat) {
-    double x = quat[0], y = quat[1], z = quat[2], w = quat[3];
+numeric_t quat_length(quat_t quat) {
+    numeric_t x = quat[0], y = quat[1], z = quat[2], w = quat[3];
     return sqrt(x * x + y * y + z * z + w * w);
 }
 
 quat_t quat_normalize(quat_t quat, quat_t dest) {
     if (!dest) { dest = quat; }
 
-    double x = quat[0], y = quat[1], z = quat[2], w = quat[3],
+    numeric_t x = quat[0], y = quat[1], z = quat[2], w = quat[3],
         len = sqrt(x * x + y * y + z * z + w * w);
     if (len == 0) {
         dest[0] = 0;
@@ -103,7 +103,7 @@ quat_t quat_normalize(quat_t quat, quat_t dest) {
 quat_t quat_multiply(quat_t quat, quat_t quat2, quat_t dest) {
     if (!dest) { dest = quat; }
 
-    double qax = quat[0], qay = quat[1], qaz = quat[2], qaw = quat[3],
+    numeric_t qax = quat[0], qay = quat[1], qaz = quat[2], qaw = quat[3],
         qbx = quat2[0], qby = quat2[1], qbz = quat2[2], qbw = quat2[3];
 
     dest[0] = qax * qbw + qaw * qbx + qay * qbz - qaz * qby;
@@ -117,7 +117,7 @@ quat_t quat_multiply(quat_t quat, quat_t quat2, quat_t dest) {
 quat_t quat_multiplyVec3(quat_t quat, vec3_t vec, vec3_t dest) {
     if (!dest) { dest = vec; }
 
-    double x = vec[0], y = vec[1], z = vec[2],
+    numeric_t x = vec[0], y = vec[1], z = vec[2],
         qx = quat[0], qy = quat[1], qz = quat[2], qw = quat[3],
 
         // calculate quat * vec
@@ -137,7 +137,7 @@ quat_t quat_multiplyVec3(quat_t quat, vec3_t vec, vec3_t dest) {
 mat3_t quat_toMat3(quat_t quat, mat3_t dest) {
     if (!dest) { dest = mat3_create(NULL); }
 
-    double x = quat[0], y = quat[1], z = quat[2], w = quat[3],
+    numeric_t x = quat[0], y = quat[1], z = quat[2], w = quat[3],
         x2 = x + x,
         y2 = y + y,
         z2 = z + z,
@@ -170,7 +170,7 @@ mat3_t quat_toMat3(quat_t quat, mat3_t dest) {
 quat_t quat_toMat4(quat_t quat, mat4_t dest) {
     if (!dest) { dest = mat4_create(NULL); }
 
-    double x = quat[0], y = quat[1], z = quat[2], w = quat[3],
+    numeric_t x = quat[0], y = quat[1], z = quat[2], w = quat[3],
         x2 = x + x,
         y2 = y + y,
         z2 = z + z,
@@ -208,10 +208,10 @@ quat_t quat_toMat4(quat_t quat, mat4_t dest) {
     return dest;
 }
 
-quat_t quat_slerp(quat_t quat, quat_t quat2, double slerp, quat_t dest) {
+quat_t quat_slerp(quat_t quat, quat_t quat2, numeric_t slerp, quat_t dest) {
     if (!dest) { dest = quat; }
 
-    double cosHalfTheta = quat[0] * quat2[0] + quat[1] * quat2[1] + quat[2] * quat2[2] + quat[3] * quat2[3],
+    numeric_t cosHalfTheta = quat[0] * quat2[0] + quat[1] * quat2[1] + quat[2] * quat2[2] + quat[3] * quat2[3],
         halfTheta,
         sinHalfTheta,
         ratioA,

--- a/quat.c
+++ b/quat.c
@@ -4,7 +4,7 @@
 #include "gl-matrix.h"
 
 quat_t quat_create(quat_t quat) {
-    quat_t dest = calloc(sizeof(double), 4);
+    quat_t dest = calloc(4, sizeof(double));
 
     if (quat) {
         dest[0] = quat[0];

--- a/quat.c
+++ b/quat.c
@@ -248,3 +248,16 @@ quat_t quat_slerp(quat_t quat, quat_t quat2, numeric_t slerp, quat_t dest) {
 
     return dest;
 }
+
+quat_t quat_rotate(quat_t q, vec3_t p, quat_t dest) {
+
+    if(!dest) {
+        dest = q;
+    }
+    numeric_t t[4] = {p[0], p[1], p[2], 0}, r[4];
+
+    quat_multiply(q, t, r);
+    quat_multiply(r, quat_conjugate(q, t), dest);
+
+    return dest;
+}

--- a/quat.c
+++ b/quat.c
@@ -261,3 +261,16 @@ quat_t quat_rotate(quat_t q, vec3_t p, quat_t dest) {
 
     return dest;
 }
+
+quat_t quat_axisFromAngle(vec3_t axis, numeric_t angle, quat_t dest) {
+	/*
+	ref: http://www.euclideanspace.com/maths/geometry/rotations/conversions/angleToQuaternion/index.htm
+	 */
+	numeric_t a[3];
+	vec3_normalize(axis, a);
+	dest[3] = cos(angle/2);
+	dest[0] = a[0] * sin(angle/2);
+	dest[1] = a[1] * sin(angle/2);
+	dest[2] = a[2] * sin(angle/2);
+	return dest;
+}

--- a/str.c
+++ b/str.c
@@ -21,9 +21,9 @@ void mat3_str(mat3_t mat, char *buffer) {
 
 void mat4_str(mat4_t mat, char *buffer) {
     sprintf(buffer, "[%f, %f, %f, %f, %f, %f, %f, %f, %f, %f, %f, %f, %f, %f, %f, %f]",
-        mat[0], mat[1], mat[2], mat[3], 
+        mat[0], mat[1], mat[2], mat[3],
         mat[4], mat[5], mat[6], mat[7],
-        mat[8], mat[9], mat[10], mat[11], 
+        mat[8], mat[9], mat[10], mat[11],
         mat[12], mat[13], mat[14], mat[15]);
 }
 

--- a/str.c
+++ b/str.c
@@ -3,8 +3,16 @@
 
 #include "gl-matrix.h"
 
+void vec2_str(vec2_t vec, char *buffer) {
+    sprintf(buffer, "[%f, %f]", vec[0], vec[1]);
+}
+
 void vec3_str(vec3_t vec, char *buffer) {
     sprintf(buffer, "[%f, %f, %f]", vec[0], vec[1], vec[2]);
+}
+
+void vec4_str(vec4_t vec, char *buffer) {
+    sprintf(buffer, "[%f, %f, %f, %f]", vec[0], vec[1], vec[2], vec[3]);
 }
 
 void mat3_str(mat3_t mat, char *buffer) {

--- a/vec2.c
+++ b/vec2.c
@@ -22,6 +22,18 @@ vec2_t vec2_set(vec2_t vec, vec2_t dest) {
     return dest;
 }
 
+vec2_t vec2_zeroes(vec2_t vec) {
+    vec[0] = 0;
+    vec[1] = 0;
+    return vec;
+}
+
+vec2_t vec2_ones(vec2_t vec) {
+    vec[0] = 1;
+    vec[1] = 1;
+    return vec;
+}
+
 vec2_t vec2_add(vec2_t vec, vec2_t vec2, vec2_t dest) {
     if (!dest || vec == dest) {
         vec[0] += vec2[0];

--- a/vec2.c
+++ b/vec2.c
@@ -4,7 +4,7 @@
 #include "gl-matrix.h"
 
 vec2_t vec2_create(vec2_t vec) {
-    vec2_t dest = calloc(2, sizeof(double));
+    vec2_t dest = calloc(2, sizeof(numeric_t));
 
     if (vec) {
         dest[0] = vec[0];
@@ -55,7 +55,7 @@ vec2_t vec2_negate(vec2_t vec, vec2_t dest) {
     return dest;
 }
 
-vec2_t vec2_scale(vec2_t vec, double val, vec2_t dest) {
+vec2_t vec2_scale(vec2_t vec, numeric_t val, vec2_t dest) {
     if (!dest || vec == dest) {
         vec[0] *= val;
         vec[1] *= val;
@@ -70,7 +70,7 @@ vec2_t vec2_scale(vec2_t vec, double val, vec2_t dest) {
 vec2_t vec2_normalize(vec2_t vec, vec2_t dest) {
     if (!dest) { dest = vec; }
 
-    double x = vec[0], y = vec[1],
+    numeric_t x = vec[0], y = vec[1],
         len = sqrt(x * x + y * y);
 
     if (!len) {
@@ -89,19 +89,19 @@ vec2_t vec2_normalize(vec2_t vec, vec2_t dest) {
     return dest;
 }
 
-double vec2_length(vec2_t vec) {
-    double x = vec[0], y = vec[1];
+numeric_t vec2_length(vec2_t vec) {
+    numeric_t x = vec[0], y = vec[1];
     return sqrt(x * x + y * y);
 }
 
-double vec2_dot(vec2_t vec, vec2_t vec2) {
+numeric_t vec2_dot(vec2_t vec, vec2_t vec2) {
     return vec[0] * vec2[0] + vec[1] * vec2[1];
 }
 
 vec2_t vec2_direction (vec2_t vec, vec2_t vec2, vec2_t dest) {
     if (!dest) { dest = vec; }
 
-    double x = vec[0] - vec2[0],
+    numeric_t x = vec[0] - vec2[0],
         y = vec[1] - vec2[1],
         len = sqrt(x * x + y * y);
 
@@ -117,15 +117,15 @@ vec2_t vec2_direction (vec2_t vec, vec2_t vec2, vec2_t dest) {
     return dest;
 }
 
-vec2_t vec2_lerp(vec2_t vec, vec2_t vec2, double lerp, vec2_t dest) {
+vec2_t vec2_lerp(vec2_t vec, vec2_t vec2, numeric_t lerp, vec2_t dest) {
     if (!dest) { dest = vec; }
     dest[0] = vec[0] + lerp * (vec2[0] - vec[0]);
     dest[1] = vec[1] + lerp * (vec2[1] - vec[1]);
     return dest;
 }
 
-double vec2_dist(vec2_t vec, vec2_t vec2) {
-    double x = vec2[0] - vec[0],
+numeric_t vec2_dist(vec2_t vec, vec2_t vec2) {
+    numeric_t x = vec2[0] - vec[0],
         y = vec2[1] - vec[1];
 
     return sqrt(x*x + y*y);

--- a/vec2.c
+++ b/vec2.c
@@ -1,0 +1,132 @@
+#include <stdlib.h>
+#include <math.h>
+
+#include "gl-matrix.h"
+
+vec2_t vec2_create(vec2_t vec) {
+    vec2_t dest = calloc(2, sizeof(double));
+
+    if (vec) {
+        dest[0] = vec[0];
+        dest[1] = vec[1];
+    } else {
+        dest[0] = dest[1] = 0;
+    }
+
+    return dest;
+}
+
+vec2_t vec2_set(vec2_t vec, vec2_t dest) {
+    dest[0] = vec[0];
+    dest[1] = vec[1];
+    return dest;
+}
+
+vec2_t vec2_add(vec2_t vec, vec2_t vec2, vec2_t dest) {
+    if (!dest || vec == dest) {
+        vec[0] += vec2[0];
+        vec[1] += vec2[1];
+        return vec;
+    }
+
+    dest[0] = vec[0] + vec2[0];
+    dest[1] = vec[1] + vec2[1];
+
+    return dest;
+}
+
+vec2_t vec2_subtract(vec2_t vec, vec2_t vec2, vec2_t dest) {
+    if (!dest || vec == dest) {
+        vec[0] -= vec2[0];
+        vec[1] -= vec2[1];
+        return vec;
+    }
+
+    dest[0] = vec[0] - vec2[0];
+    dest[1] = vec[1] - vec2[1];
+    return dest;
+}
+
+vec2_t vec2_negate(vec2_t vec, vec2_t dest) {
+    if (!dest) { dest = vec; }
+
+    dest[0] = -vec[0];
+    dest[1] = -vec[1];
+    return dest;
+}
+
+vec2_t vec2_scale(vec2_t vec, double val, vec2_t dest) {
+    if (!dest || vec == dest) {
+        vec[0] *= val;
+        vec[1] *= val;
+        return vec;
+    }
+
+    dest[0] = vec[0] * val;
+    dest[1] = vec[1] * val;
+    return dest;
+}
+
+vec2_t vec2_normalize(vec2_t vec, vec2_t dest) {
+    if (!dest) { dest = vec; }
+
+    double x = vec[0], y = vec[1],
+        len = sqrt(x * x + y * y);
+
+    if (!len) {
+        dest[0] = 0;
+        dest[1] = 0;
+        return dest;
+    } else if (len == 1) {
+        dest[0] = x;
+        dest[1] = y;
+        return dest;
+    }
+
+    len = 1 / len;
+    dest[0] = x * len;
+    dest[1] = y * len;
+    return dest;
+}
+
+double vec2_length(vec2_t vec) {
+    double x = vec[0], y = vec[1];
+    return sqrt(x * x + y * y);
+}
+
+double vec2_dot(vec2_t vec, vec2_t vec2) {
+    return vec[0] * vec2[0] + vec[1] * vec2[1];
+}
+
+vec2_t vec2_direction (vec2_t vec, vec2_t vec2, vec2_t dest) {
+    if (!dest) { dest = vec; }
+
+    double x = vec[0] - vec2[0],
+        y = vec[1] - vec2[1],
+        len = sqrt(x * x + y * y);
+
+    if (!len) {
+        dest[0] = 0;
+        dest[1] = 0;
+        return dest;
+    }
+
+    len = 1 / len;
+    dest[0] = x * len;
+    dest[1] = y * len;
+    return dest;
+}
+
+vec2_t vec2_lerp(vec2_t vec, vec2_t vec2, double lerp, vec2_t dest) {
+    if (!dest) { dest = vec; }
+    dest[0] = vec[0] + lerp * (vec2[0] - vec[0]);
+    dest[1] = vec[1] + lerp * (vec2[1] - vec[1]);
+    return dest;
+}
+
+double vec2_dist(vec2_t vec, vec2_t vec2) {
+    double x = vec2[0] - vec[0],
+        y = vec2[1] - vec[1];
+
+    return sqrt(x*x + y*y);
+}

--- a/vec3.c
+++ b/vec3.c
@@ -4,7 +4,7 @@
 #include "gl-matrix.h"
 
 vec3_t vec3_create(vec3_t vec) {
-    vec3_t dest = calloc(sizeof(double_t), 3);
+    vec3_t dest = calloc(3, sizeof(double));
 
     if (vec) {
         dest[0] = vec[0];

--- a/vec3.c
+++ b/vec3.c
@@ -4,7 +4,7 @@
 #include "gl-matrix.h"
 
 vec3_t vec3_create(vec3_t vec) {
-    vec3_t dest = calloc(3, sizeof(double));
+    vec3_t dest = calloc(3, sizeof(numeric_t));
 
     if (vec) {
         dest[0] = vec[0];
@@ -77,7 +77,7 @@ vec3_t vec3_negate(vec3_t vec, vec3_t dest) {
     return dest;
 }
 
-vec3_t vec3_scale(vec3_t vec, double val, vec3_t dest) {
+vec3_t vec3_scale(vec3_t vec, numeric_t val, vec3_t dest) {
     if (!dest || vec == dest) {
         vec[0] *= val;
         vec[1] *= val;
@@ -94,7 +94,7 @@ vec3_t vec3_scale(vec3_t vec, double val, vec3_t dest) {
 vec3_t vec3_normalize(vec3_t vec, vec3_t dest) {
     if (!dest) { dest = vec; }
 
-    double x = vec[0], y = vec[1], z = vec[2],
+    numeric_t x = vec[0], y = vec[1], z = vec[2],
         len = sqrt(x * x + y * y + z * z);
 
     if (!len) {
@@ -119,7 +119,7 @@ vec3_t vec3_normalize(vec3_t vec, vec3_t dest) {
 vec3_t vec3_cross (vec3_t vec, vec3_t vec2, vec3_t dest) {
     if (!dest) { dest = vec; }
 
-    double x = vec[0], y = vec[1], z = vec[2],
+    numeric_t x = vec[0], y = vec[1], z = vec[2],
         x2 = vec2[0], y2 = vec2[1], z2 = vec2[2];
 
     dest[0] = y * z2 - z * y2;
@@ -128,19 +128,19 @@ vec3_t vec3_cross (vec3_t vec, vec3_t vec2, vec3_t dest) {
     return dest;
 }
 
-double vec3_length(vec3_t vec) {
-    double x = vec[0], y = vec[1], z = vec[2];
+numeric_t vec3_length(vec3_t vec) {
+    numeric_t x = vec[0], y = vec[1], z = vec[2];
     return sqrt(x * x + y * y + z * z);
 }
 
-double vec3_dot(vec3_t vec, vec3_t vec2) {
+numeric_t vec3_dot(vec3_t vec, vec3_t vec2) {
     return vec[0] * vec2[0] + vec[1] * vec2[1] + vec[2] * vec2[2];
 }
 
 vec3_t vec3_direction (vec3_t vec, vec3_t vec2, vec3_t dest) {
     if (!dest) { dest = vec; }
 
-    double x = vec[0] - vec2[0],
+    numeric_t x = vec[0] - vec2[0],
         y = vec[1] - vec2[1],
         z = vec[2] - vec2[2],
         len = sqrt(x * x + y * y + z * z);
@@ -159,7 +159,7 @@ vec3_t vec3_direction (vec3_t vec, vec3_t vec2, vec3_t dest) {
     return dest;
 }
 
-vec3_t vec3_lerp(vec3_t vec, vec3_t vec2, double lerp, vec3_t dest) {
+vec3_t vec3_lerp(vec3_t vec, vec3_t vec2, numeric_t lerp, vec3_t dest) {
     if (!dest) { dest = vec; }
 
     dest[0] = vec[0] + lerp * (vec2[0] - vec[0]);
@@ -169,8 +169,8 @@ vec3_t vec3_lerp(vec3_t vec, vec3_t vec2, double lerp, vec3_t dest) {
     return dest;
 }
 
-double vec3_dist(vec3_t vec, vec3_t vec2) {
-    double x = vec2[0] - vec[0],
+numeric_t vec3_dist(vec3_t vec, vec3_t vec2) {
+    numeric_t x = vec2[0] - vec[0],
         y = vec2[1] - vec[1],
         z = vec2[2] - vec[2];
         
@@ -181,7 +181,7 @@ vec3_t vec3_unproject(vec3_t vec, mat4_t view, mat4_t proj, vec4_t viewport, vec
     if (!dest) { dest = vec; }
 
     mat4_t m = mat4_create(NULL);
-    double *v = malloc(sizeof(double) * 4);
+    numeric_t *v = malloc(sizeof(numeric_t) * 4);
     
     v[0] = (vec[0] - viewport[0]) * 2.0 / viewport[2] - 1.0;
     v[1] = (vec[1] - viewport[1]) * 2.0 / viewport[3] - 1.0;

--- a/vec3.c
+++ b/vec3.c
@@ -25,6 +25,20 @@ vec3_t vec3_set(vec3_t vec, vec3_t dest) {
     return dest;
 }
 
+vec3_t vec3_zeroes(vec3_t vec) {
+    vec[0] = 0;
+    vec[1] = 0;
+    vec[2] = 0;
+    return vec;
+}
+
+vec3_t vec3_ones(vec3_t vec) {
+    vec[0] = 1;
+    vec[1] = 1;
+    vec[2] = 1;
+    return vec;
+}
+
 vec3_t vec3_add(vec3_t vec, vec3_t vec2, vec3_t dest) {
     if (!dest || vec == dest) {
         vec[0] += vec2[0];
@@ -36,7 +50,7 @@ vec3_t vec3_add(vec3_t vec, vec3_t vec2, vec3_t dest) {
     dest[0] = vec[0] + vec2[0];
     dest[1] = vec[1] + vec2[1];
     dest[2] = vec[2] + vec2[2];
-    
+
     return dest;
 }
 
@@ -173,7 +187,7 @@ numeric_t vec3_dist(vec3_t vec, vec3_t vec2) {
     numeric_t x = vec2[0] - vec[0],
         y = vec2[1] - vec[1],
         z = vec2[2] - vec[2];
-        
+
     return sqrt(x*x + y*y + z*z);
 }
 
@@ -182,21 +196,21 @@ vec3_t vec3_unproject(vec3_t vec, mat4_t view, mat4_t proj, vec4_t viewport, vec
 
     mat4_t m = mat4_create(NULL);
     numeric_t *v = malloc(sizeof(numeric_t) * 4);
-    
+
     v[0] = (vec[0] - viewport[0]) * 2.0 / viewport[2] - 1.0;
     v[1] = (vec[1] - viewport[1]) * 2.0 / viewport[3] - 1.0;
     v[2] = 2.0 * vec[2] - 1.0;
     v[3] = 1.0;
-    
+
     mat4_multiply(proj, view, m);
     if(!mat4_inverse(m, NULL)) { return NULL; }
-    
+
     mat4_multiplyVec4(m, v, NULL);
     if(v[3] == 0.0) { return NULL; }
 
     dest[0] = v[0] / v[3];
     dest[1] = v[1] / v[3];
     dest[2] = v[2] / v[3];
-    
+
     return dest;
 }

--- a/vec4.c
+++ b/vec4.c
@@ -26,6 +26,22 @@ vec4_t vec4_set(vec4_t vec, vec4_t dest) {
     return dest;
 }
 
+vec4_t vec4_zeroes(vec4_t vec) {
+    vec[0] = 0;
+    vec[1] = 0;
+    vec[2] = 0;
+    vec[3] = 0;
+    return vec;
+}
+
+vec4_t vec4_ones(vec4_t vec) {
+    vec[0] = 1;
+    vec[1] = 1;
+    vec[2] = 1;
+    vec[3] = 1;
+    return vec;
+}
+
 vec4_t vec4_add(vec4_t vec, vec4_t vec2, vec4_t dest) {
     if (!dest || vec == dest) {
         vec[0] += vec2[0];
@@ -39,7 +55,7 @@ vec4_t vec4_add(vec4_t vec, vec4_t vec2, vec4_t dest) {
     dest[1] = vec[1] + vec2[1];
     dest[2] = vec[2] + vec2[2];
     dest[3] = vec[3] + vec2[3];
-    
+
     return dest;
 }
 
@@ -163,6 +179,6 @@ numeric_t vec4_dist(vec4_t vec, vec4_t vec2) {
         y = vec2[1] - vec[1],
         z = vec2[2] - vec[2],
         w = vec2[3] - vec[3];
-        
+
     return sqrt(x*x + y*y + z*z + w*w);
 }

--- a/vec4.c
+++ b/vec4.c
@@ -1,0 +1,168 @@
+#include <stdlib.h>
+#include <math.h>
+
+#include "gl-matrix.h"
+
+vec4_t vec4_create(vec4_t vec) {
+    vec4_t dest = calloc(4, sizeof(double));
+
+    if (vec) {
+        dest[0] = vec[0];
+        dest[1] = vec[1];
+        dest[2] = vec[2];
+        dest[3] = vec[3];
+    } else {
+        dest[0] = dest[1] = dest[2] = dest[3] = 0;
+    }
+
+    return dest;
+}
+
+vec4_t vec4_set(vec4_t vec, vec4_t dest) {
+    dest[0] = vec[0];
+    dest[1] = vec[1];
+    dest[2] = vec[2];
+    dest[3] = vec[3];
+    return dest;
+}
+
+vec4_t vec4_add(vec4_t vec, vec4_t vec2, vec4_t dest) {
+    if (!dest || vec == dest) {
+        vec[0] += vec2[0];
+        vec[1] += vec2[1];
+        vec[2] += vec2[2];
+        vec[3] += vec2[3];
+        return vec;
+    }
+
+    dest[0] = vec[0] + vec2[0];
+    dest[1] = vec[1] + vec2[1];
+    dest[2] = vec[2] + vec2[2];
+    dest[3] = vec[3] + vec2[3];
+    
+    return dest;
+}
+
+vec4_t vec4_subtract(vec4_t vec, vec4_t vec2, vec4_t dest) {
+    if (!dest || vec == dest) {
+        vec[0] -= vec2[0];
+        vec[1] -= vec2[1];
+        vec[2] -= vec2[2];
+        vec[3] -= vec2[3];
+        return vec;
+    }
+
+    dest[0] = vec[0] - vec2[0];
+    dest[1] = vec[1] - vec2[1];
+    dest[2] = vec[2] - vec2[2];
+    dest[3] = vec[3] - vec2[3];
+    return dest;
+}
+
+vec4_t vec4_negate(vec4_t vec, vec4_t dest) {
+    if (!dest) { dest = vec; }
+
+    dest[0] = -vec[0];
+    dest[1] = -vec[1];
+    dest[2] = -vec[2];
+    dest[3] = -vec[3];
+    return dest;
+}
+
+vec4_t vec4_scale(vec4_t vec, double val, vec4_t dest) {
+    if (!dest || vec == dest) {
+        vec[0] *= val;
+        vec[1] *= val;
+        vec[2] *= val;
+        vec[3] *= val;
+        return vec;
+    }
+
+    dest[0] = vec[0] * val;
+    dest[1] = vec[1] * val;
+    dest[2] = vec[2] * val;
+    dest[3] = vec[3] * val;
+    return dest;
+}
+
+vec4_t vec4_normalize(vec4_t vec, vec4_t dest) {
+    if (!dest) { dest = vec; }
+
+    double x = vec[0], y = vec[1], z = vec[2], w = vec[3],
+        len = sqrt(x * x + y * y + z * z + w * w);
+
+    if (!len) {
+        dest[0] = 0;
+        dest[1] = 0;
+        dest[2] = 0;
+        dest[3] = 0;
+        return dest;
+    } else if (len == 1) {
+        dest[0] = x;
+        dest[1] = y;
+        dest[2] = z;
+        dest[3] = z;
+        return dest;
+    }
+
+    len = 1 / len;
+    dest[0] = x * len;
+    dest[1] = y * len;
+    dest[2] = z * len;
+    dest[3] = w * len;
+    return dest;
+}
+
+double vec4_length(vec4_t vec) {
+    double x = vec[0], y = vec[1], z = vec[2], w = vec[3];
+    return sqrt(x * x + y * y + z * z + w * w);
+}
+
+double vec4_dot(vec4_t vec, vec4_t vec2) {
+    return vec[0] * vec2[0] + vec[1] * vec2[1] + vec[2] * vec2[2] + vec[3] * vec2[3];
+}
+
+vec4_t vec4_direction (vec4_t vec, vec4_t vec2, vec4_t dest) {
+    if (!dest) { dest = vec; }
+
+    double x = vec[0] - vec2[0],
+        y = vec[1] - vec2[1],
+        z = vec[2] - vec2[2],
+        w = vec[3] - vec2[3],
+        len = sqrt(x * x + y * y + z * z + w * w);
+
+    if (!len) {
+        dest[0] = 0;
+        dest[1] = 0;
+        dest[2] = 0;
+        dest[3] = 0;
+        return dest;
+    }
+
+    len = 1 / len;
+    dest[0] = x * len;
+    dest[1] = y * len;
+    dest[2] = z * len;
+    dest[3] = w * len;
+    return dest;
+}
+
+vec4_t vec4_lerp(vec4_t vec, vec4_t vec2, double lerp, vec4_t dest) {
+    if (!dest) { dest = vec; }
+
+    dest[0] = vec[0] + lerp * (vec2[0] - vec[0]);
+    dest[1] = vec[1] + lerp * (vec2[1] - vec[1]);
+    dest[2] = vec[2] + lerp * (vec2[2] - vec[2]);
+    dest[3] = vec[3] + lerp * (vec2[3] - vec[3]);
+
+    return dest;
+}
+
+double vec4_dist(vec4_t vec, vec4_t vec2) {
+    double x = vec2[0] - vec[0],
+        y = vec2[1] - vec[1],
+        z = vec2[2] - vec[2],
+        w = vec2[3] - vec[3];
+        
+    return sqrt(x*x + y*y + z*z + w*w);
+}

--- a/vec4.c
+++ b/vec4.c
@@ -4,7 +4,7 @@
 #include "gl-matrix.h"
 
 vec4_t vec4_create(vec4_t vec) {
-    vec4_t dest = calloc(4, sizeof(double));
+    vec4_t dest = calloc(4, sizeof(numeric_t));
 
     if (vec) {
         dest[0] = vec[0];
@@ -69,7 +69,7 @@ vec4_t vec4_negate(vec4_t vec, vec4_t dest) {
     return dest;
 }
 
-vec4_t vec4_scale(vec4_t vec, double val, vec4_t dest) {
+vec4_t vec4_scale(vec4_t vec, numeric_t val, vec4_t dest) {
     if (!dest || vec == dest) {
         vec[0] *= val;
         vec[1] *= val;
@@ -88,7 +88,7 @@ vec4_t vec4_scale(vec4_t vec, double val, vec4_t dest) {
 vec4_t vec4_normalize(vec4_t vec, vec4_t dest) {
     if (!dest) { dest = vec; }
 
-    double x = vec[0], y = vec[1], z = vec[2], w = vec[3],
+    numeric_t x = vec[0], y = vec[1], z = vec[2], w = vec[3],
         len = sqrt(x * x + y * y + z * z + w * w);
 
     if (!len) {
@@ -113,19 +113,19 @@ vec4_t vec4_normalize(vec4_t vec, vec4_t dest) {
     return dest;
 }
 
-double vec4_length(vec4_t vec) {
-    double x = vec[0], y = vec[1], z = vec[2], w = vec[3];
+numeric_t vec4_length(vec4_t vec) {
+    numeric_t x = vec[0], y = vec[1], z = vec[2], w = vec[3];
     return sqrt(x * x + y * y + z * z + w * w);
 }
 
-double vec4_dot(vec4_t vec, vec4_t vec2) {
+numeric_t vec4_dot(vec4_t vec, vec4_t vec2) {
     return vec[0] * vec2[0] + vec[1] * vec2[1] + vec[2] * vec2[2] + vec[3] * vec2[3];
 }
 
 vec4_t vec4_direction (vec4_t vec, vec4_t vec2, vec4_t dest) {
     if (!dest) { dest = vec; }
 
-    double x = vec[0] - vec2[0],
+    numeric_t x = vec[0] - vec2[0],
         y = vec[1] - vec2[1],
         z = vec[2] - vec2[2],
         w = vec[3] - vec2[3],
@@ -147,7 +147,7 @@ vec4_t vec4_direction (vec4_t vec, vec4_t vec2, vec4_t dest) {
     return dest;
 }
 
-vec4_t vec4_lerp(vec4_t vec, vec4_t vec2, double lerp, vec4_t dest) {
+vec4_t vec4_lerp(vec4_t vec, vec4_t vec2, numeric_t lerp, vec4_t dest) {
     if (!dest) { dest = vec; }
 
     dest[0] = vec[0] + lerp * (vec2[0] - vec[0]);
@@ -158,8 +158,8 @@ vec4_t vec4_lerp(vec4_t vec, vec4_t vec2, double lerp, vec4_t dest) {
     return dest;
 }
 
-double vec4_dist(vec4_t vec, vec4_t vec2) {
-    double x = vec2[0] - vec[0],
+numeric_t vec4_dist(vec4_t vec, vec4_t vec2) {
+    numeric_t x = vec2[0] - vec[0],
         y = vec2[1] - vec[1],
         z = vec2[2] - vec[2],
         w = vec2[3] - vec[3];


### PR DESCRIPTION
Hi, thanks for this library. It is very convenient to have a simple library like this for my graphics hobbies.

Here are some changes I've made to my fork to eliminate some compiler warnings:

- For some `calloc()` calls I've swapped the `nitems` and `size` parameters
- `mat4_multiplyVec3` and `mat4_multiplyVec4` had the wrong parameters and return types
- I've added `.o` to the `all` target in the Makefile to eliminate some unnecessary compiles